### PR TITLE
Update Hugo to v0.160.1 and fix theme compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Hugo output
+public/
+resources/_gen/
+.hugo_build.lock
+
 # Binaries for programs and plugins
 *.exe
 *.exe~
@@ -11,8 +16,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
-node_modules
-.vscode
-resources
+# Dependency directories
+node_modules/
+.vscode/
+.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,72 @@
-# deardhruv.com
-personal website
+# Dhruv's Blog ([deardhruv.com](https://deardhruv.com))
+
+Welcome to my personal website and blog repository. This site is built with Hugo, a fast and flexible static site generator, and is currently hosted on Netlify.
+
+## ✨ Features
+
+- **Theme**: [hello-friend-ng](https://github.com/rhazdon/hugo-theme-hello-friend-ng) - A clean and minimal dark/light theme for bloggers.
+- **Fast Performance**: Static site generation ensures quick loading times.
+- **Responsive Design**: Optimized for mobile, tablet, and desktop viewing.
+- **Social Integration**: Easy access to my social media profiles.
+
+## 🛠 Prerequisites
+
+Before you begin, ensure you have the following installed:
+
+- [Hugo (Extended version)](https://gohugo.io/getting-started/installing/)
+- [Git](https://git-scm.com/downloads)
+
+## 🚀 Getting Started
+
+To run the site locally for development:
+
+1.  **Clone the repository:**
+
+    ```bash
+    git clone https://github.com/DearDhruv/deardhruv.com.git
+    cd deardhruv.com
+    ```
+
+2.  **Initialize and update submodules:**
+
+    The theme is included as a git submodule.
+
+    ```bash
+    git submodule init
+    git submodule update
+    ```
+
+3.  **Run the Hugo server:**
+
+    ```bash
+    hugo server -D
+    ```
+
+    The site will be available at `http://localhost:1313/`. The `-D` flag includes draft posts.
+
+## 📁 Project Structure
+
+- `/content`: Where all the blog posts (`/posts`) and pages (`about.md`) are stored.
+- `/themes`: Contains the `hello-friend-ng` theme as a submodule.
+- `config.toml`: Main configuration file for site-wide settings, menus, and social links.
+- `netlify.toml`: Configuration for Netlify deployment and build settings.
+
+## 🌐 Deployment
+
+This site is automatically deployed to Netlify on every push to the `master` branch. The build command used is:
+
+```bash
+hugo --gc --minify
+```
+
+## 👨‍💻 Connect with Me
+
+- **Twitter**: [@DearDhruv](https://twitter.com/DearDhruv)
+- **GitHub**: [DearDhruv](https://github.com/DearDhruv)
+- **LinkedIn**: [Dhruv Patel](https://www.linkedin.com/in/DearDhruv)
+- **Instagram**: [@deardhruv](https://www.instagram.com/deardhruv)
+- **StackOverflow**: [deardhruv](https://www.stackoverflow.com/users/596566/deardhruv)
+
+## 📄 License
+
+This work is licensed under a [Creative Commons Attribution-NonCommercial 4.0 International License](https://creativecommons.org/licenses/by-nc/4.0/).

--- a/config.toml
+++ b/config.toml
@@ -37,9 +37,6 @@ disableHugoGeneratorInject = false
 [permalinks]
   posts = "/posts/:year/:month/:title/"
 
-[author]
-  name = "Dhruv Patel"
-
 [blackfriday]
   hrefTargetBlank = true
 
@@ -59,6 +56,23 @@ disableHugoGeneratorInject = false
   images = [""]
 
   homeSubtitle = "A step towards technology"
+
+  [params.Author]
+    name = "Dhruv Patel"
+    email = "dhruv@deardhruv.com"
+
+  [params.footer]
+    trademark = "Dhruv Patel"
+    author = true
+    copyright = true
+    rss = true
+    # topText = ["Left text", "Right text"]
+    bottomText = ["Powered by <a href=\"http://gohugo.io\">Hugo</a>", "Made with &#10084; by <a href=\"https://github.com/rhazdon\">Djordje Atlialp</a>"]
+
+  # Plausible.io (Optional)
+  # plausibleDataDomain = ""
+  # plausibleScriptSource = ""
+
 
   # Prefix of link to the git commit detail page. GitInfo must be enabled.
   # gitUrl = ""

--- a/content/about.md
+++ b/content/about.md
@@ -1,6 +1,6 @@
 +++
 title = "About"
-date = "03-08-2022"
+date = "2022-08-03"
 aliases = ["about-us","about-hugo","contact"]
 [ author ]
   name = "Dhruv Patel"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,22 @@
+<footer class="footer">
+    <div class="footer__inner">
+        <div class="footer__content">
+            <span>&copy; {{ now.Format "2006" }}</span>
+            {{/* Fixed .Site.Author for Hugo v0.123+ compatibility */}}
+            {{ $authorName := .Site.Params.author.name }}
+            {{ if $authorName }}
+                <span><a href="{{ .Site.BaseURL }}">{{ $authorName }}</a></span>
+            {{ end }}
+            {{ if .Site.Copyright }}
+                <span>{{ .Site.Copyright| safeHTML }}</span>
+            {{ end }}
+            <span>{{- if not .Site.Params.disableRSS }} <a href="{{ "posts/index.xml" | absLangURL }}" target="_blank" title="rss"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-rss"><path d="M4 11a9 9 0 0 1 9 9"></path><path d="M4 4a16 16 0 0 1 16 16"></path><circle cx="5" cy="19" r="1"></circle></svg></a>{{ end }}</span>
+        </div>
+    </div>
+    <div class="footer__inner">
+        <div class="footer__content">
+            <span>Powered by <a href="http://gohugo.io">Hugo</a></span>
+            <span>Made with &#10084; by <a href="https://github.com/rhazdon">Djordje Atlialp</a></span>
+        </div>
+    </div>
+</footer>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,76 @@
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="ie=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+{{/* Fixed .Site.Author for Hugo v0.123+ compatibility */}}
+{{ $author := .Params.author | default .Site.Params.author }}
+<meta name="author" content="{{ if reflect.IsMap $author }}{{ $author.name }}{{ else }}{{ $author }}{{ end }}">
+<meta name="description" content="{{ if .IsHome }}{{ .Site.Params.homeSubtitle }}{{ else }}{{ .Summary | plainify }}{{ end }}" />
+<meta name="keywords" content="{{ .Site.Params.keywords }}{{ if .Params.tags }}{{ range .Params.tags }}, {{ . }}{{ end }}{{ end }}" />
+<meta name="robots" content="noodp" />
+<meta name="theme-color" content="{{ .Site.Params.themeColor }}" />
+<link rel="canonical" href="{{ .Permalink }}" />
+
+{{ block "title" . }}
+    <title>
+        {{ if .IsHome }}
+            {{ $.Site.Title }} {{ with $.Site.Params.Subtitle }} — {{ . }} {{ end }}
+        {{ else }}
+            {{ .Title }} :: {{ $.Site.Title }} {{ with $.Site.Params.Subtitle }} — {{ . }}{{ end }}
+        {{ end }}
+    </title>
+{{ end }}
+
+<!-- CSS -->
+<link href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.2.1/css/flag-icon.min.css" rel="stylesheet"
+    type="text/css">
+
+{{ $options := (dict "targetPath" "main.css" "outputStyle" "compressed" "enableSourceMap" true) }}
+{{/* Safer resource getting for Hugo v0.123+ */}}
+{{ $mainScss := resources.Get "scss/main.scss" }}
+{{ if $mainScss }}
+    {{ $style := $mainScss | toCSS $options | fingerprint }}
+    <link rel="stylesheet" href="{{ $style.RelPermalink }}">
+{{ else }}
+    {{/* Fallback if theme assets are not being picked up correctly */}}
+    <link rel="stylesheet" href="{{ "main.css" | absURL }}">
+{{ end }}
+
+{{ range $val := $.Site.Params.customCSS }}
+    {{ if gt (len $val) 0 }}
+        <link rel="stylesheet" type="text/css" href="{{ $val }}">
+    {{ end }}
+{{ end }}
+
+<!-- Icons -->
+{{- partial "favicons.html" . }}
+
+{{ template "_internal/schema.html" . }}
+{{ template "_internal/twitter_cards.html" . }}
+
+{{ if isset .Site.Taxonomies "series" }}
+    {{ template "_internal/opengraph.html" . }}
+{{ end }}
+
+{{ range .Params.categories }}
+    <meta property="article:section" content="{{ . }}" />
+{{ end }}
+
+{{ if isset .Params "date" }}
+    <meta property="article:published_time" content="{{ time .Date }}" />
+{{ end }}
+
+<!-- RSS -->
+{{ with .OutputFormats.Get "rss" -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+{{ end -}}
+
+<!-- JSON Feed -->
+{{ if .OutputFormats.Get "json" }}
+<link href="{{ if .OutputFormats.Get "json" }}{{ .Site.BaseURL }}feed.json{{ end }}" rel="alternate"
+    type="application/json" title="{{ .Site.Title }}" />
+{{ end }}
+
+<!-- Custom head tags -->
+{{- if templates.Exists "partials/extra-head.html" -}}
+    {{ partial "extra-head.html" . }}
+{{- end }}

--- a/layouts/posts/rss.xml
+++ b/layouts/posts/rss.xml
@@ -1,0 +1,33 @@
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+        <link>{{ .Permalink }}</link>
+        <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+        <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+        <language>{{.}}</language>{{end}}
+        {{/* Fixed .Site.Author for Hugo v0.123+ compatibility */}}
+        {{ $authorEmail := .Site.Params.author.email }}
+        {{ $authorName := .Site.Params.author.name }}
+        {{ with $authorEmail }}
+        <managingEditor>{{.}}{{ with $authorName }} ({{.}}){{end}}</managingEditor>
+        <webMaster>{{.}}{{ with $authorName }} ({{.}}){{end}}</webMaster>
+        {{end}}
+        {{ with .Site.Copyright }}
+        <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
+        <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+        {{ with .OutputFormats.Get "RSS" -}}
+            {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+        {{ end -}}
+        {{ range .Pages }}
+        <item>
+            <title>{{ .Title }}</title>
+            <link>{{ .Permalink }}</link>
+            <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+            {{ with $authorEmail }}<author>{{.}}{{ with $authorName }} ({{.}}){{end}}</author>{{end}}
+            <guid>{{ .Permalink }}</guid>
+            <description>{{ .Summary | html }}</description>
+            <content type="html">{{ printf `<![CDATA[%s]]>` .Content | safeHTML }}</content>
+        </item>
+        {{ end }}
+    </channel>
+</rss>

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "hugo --gc --minify"
 
 [context.production.environment]
-HUGO_VERSION = "0.70.0"
+HUGO_VERSION = "0.160.1"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
@@ -11,20 +11,20 @@ HUGO_ENABLEGITINFO = "true"
 command = "hugo --gc --minify --enableGitInfo"
 
 [context.split1.environment]
-HUGO_VERSION = "0.70.0"
+HUGO_VERSION = "0.160.1"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
 command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.70.0"
+HUGO_VERSION = "0.160.1"
 
 [context.branch-deploy]
 command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.70.0"
+HUGO_VERSION = "0.160.1"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "hugo": {
+    "enabled": true
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ],
+  "rangeStrategy": "pin"
 }


### PR DESCRIPTION
- Bump Hugo version to 0.160.1 in `netlify.toml`.
- Update `hello-friend-ng` theme submodule.
- Add custom `head.html`, `footer.html`, and `rss.xml` layouts to fix `Site.Author` compatibility for Hugo v0.123+.
- Rewrite `README.md` with features, prerequisites, and setup instructions.
- Update `.gitignore` to include Hugo output and IDE-specific files.
- Reorganize author parameters and footer configuration in `config.toml`.
- Configure `renovate.json` for Hugo updates and minor version automerge.
- Standardize date format in `content/about.md`.